### PR TITLE
kairo-implement の出力先に影響が出ないように、出力フォーマットを修正

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -262,13 +262,12 @@ Kairoは各タスクに対して内部的にTDDコマンドを使用して以下
 ├── .claude/
 │   └── commands/           # Kairoコマンド
 ├── docs/
+│   └── implements/        # 実装コード
+│         └── {タスクID}/
 │   ├── spec/              # 要件定義書
 │   ├── design/            # 設計文書
 │   ├── tasks/             # タスク一覧
 │   └── reverse/           # リバース文書
-├── implementation/        # 実装コード
-│   └── {要件名}/
-│       └── {タスクID}/
 ├── backend/              # バックエンドコード
 ├── frontend/             # フロントエンドコード
 └── database/             # データベース関連

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -262,8 +262,8 @@ Kairoは各タスクに対して内部的にTDDコマンドを使用して以下
 ├── .claude/
 │   └── commands/           # Kairoコマンド
 ├── docs/
-│   └── implements/        # 実装コード
-│         └── {タスクID}/
+│   ├── implements/        # 実装コード
+│   │   └── {タスクID}/
 │   ├── spec/              # 要件定義書
 │   ├── design/            # 設計文書
 │   ├── tasks/             # タスク一覧

--- a/commands/kairo-implement.md
+++ b/commands/kairo-implement.md
@@ -287,7 +287,7 @@ $ claude code kairo-implement --status
 
 ```
 ✅ Task 1/6: @task tdd-requirements 完了
-   ファイル: /implementation/{要件名}/TASK-101/requirements.md
+   ファイル: docs/implements/TASK-101/{要件名}-requirements.md
    Task実行結果: 要件定義書作成完了
 
 🏃 Task 2/6: @task tdd-testcases 実行中...


### PR DESCRIPTION
- 関連: #23 

上記 issue で tdd-* コマンドの出力先のほうが正しいと確認したため、変更を加えました。

### 変更内容
- `kairo-implement` のフォーマット例のファイル出力パスが一致していなかったため、出力フォーマット例を変更
- MANUAL.md のディレクトリ構成も上記に従う形に変更

### 気になったものの変更していないこと
- `{TASK-ID}`,`{{task_id}}`, `{feature_name}`,`{要件名}` などの表記ゆれ
- 出力フォーマット例で、タスク番号が3桁のものがあるが、kairo-tasks では4桁を出力するように指示されている
