### PR TITLE
Fix formatting for API specification in markdown

### DIFF
--- a/book/03-process/02-todo-and-specification.md
+++ b/book/03-process/02-todo-and-specification.md
@@ -170,7 +170,7 @@ TODOから具体的な技術仕様を策定し、実装の方向性を明確に�
 ## 技術仕様
 
 ### API仕様
-```
+```http
 POST /api/users
 Content-Type: application/json
 


### PR DESCRIPTION
before

<img width="1291" height="589" alt="image" src="https://github.com/user-attachments/assets/9abb3528-8b85-4163-abda-9320ee24f338" />

after

<img width="1291" height="589" alt="image" src="https://github.com/user-attachments/assets/b0105a81-a0e0-4196-a104-a4319d06edc8" />
