### PR TITLE
ドキュメントのディレクトリ名を実際に生成されるディレクトリ名に統一しました

### DIFF
--- a/book/03-process/02-todo-and-specification.md
+++ b/book/03-process/02-todo-and-specification.md
@@ -60,9 +60,9 @@ AITDDにおいて、適切なTODO作成は成功の鍵となります。曖昧�
 #### ファイル構成の推奨事項
 
 ```
-doc/
+docs/
 ├── todo.md                    # メインTODO管理
-├── implementation/
+├── implements/
 │   ├── user-auth-requirements.md      # 個別機能の詳細仕様
 │   ├── user-auth-testcases.md         # テストケース
 │   └── search-requirements.md

--- a/book/03-process/02-todo-and-specification.md
+++ b/book/03-process/02-todo-and-specification.md
@@ -61,13 +61,15 @@ AITDDにおいて、適切なTODO作成は成功の鍵となります。曖昧�
 
 ```
 docs/
-├── todo.md                    # メインTODO管理
+├── todo.md                                # メインTODO管理
 ├── implements/
-│   ├── user-auth-requirements.md      # 個別機能の詳細仕様
-│   ├── user-auth-testcases.md         # テストケース
-│   └── search-requirements.md
+│    ├──TASK-101/
+│    │  ├── user-auth-requirements.md    # 個別機能の詳細仕様
+│    │  └── user-auth-testcases.md       # テストケース
+│    └──TASK-201/
+│        └── search-requirements.md
 └── archive/
-    └── completed-todos.md              # 完了したTODOのアーカイブ
+    └── completed-todos.md                # 完了したTODOのアーカイブ
 ```
 
 ## 仕様策定：設計の基盤

--- a/book/03-process/05-validation-details.md
+++ b/book/03-process/05-validation-details.md
@@ -84,13 +84,13 @@ Coverage: 94%
 ## ドキュメント確認リスト
 
 ### 必須ファイル
-- doc/implementation/{feature_name}-requirements.md
-- doc/implementation/{feature_name}-testcases.md  
-- doc/todo.md
+- docs/implements/{feature_name}-requirements.md
+- docs/implements/{feature_name}-testcases.md  
+- docs/todo.md
 
 ### オプションファイル（存在する場合）
-- doc/implementation/{test_case_name}-memo.md
-- doc/implementation/{feature_name}-architecture.md
+- docs/implements/{test_case_name}-memo.md
+- docs/implements/{feature_name}-architecture.md
 ```
 
 #### 確認内容例

--- a/book/03-process/05-validation-details.md
+++ b/book/03-process/05-validation-details.md
@@ -84,13 +84,13 @@ Coverage: 94%
 ## ドキュメント確認リスト
 
 ### 必須ファイル
-- docs/implements/{feature_name}-requirements.md
-- docs/implements/{feature_name}-testcases.md  
+- docs/implements/{{task_id}}/{feature_name}-requirements.md
+- docs/implements/{{task_id}}/{feature_name}-testcases.md  
 - docs/todo.md
 
 ### オプションファイル（存在する場合）
-- docs/implements/{test_case_name}-memo.md
-- docs/implements/{feature_name}-architecture.md
+- docs/implements/{{task_id}}/{test_case_name}-memo.md
+- docs/implements/{{task_id}}/{feature_name}-architecture.md
 ```
 
 #### 確認内容例


### PR DESCRIPTION
ドキュメントに実際に生成されるディレクトリ名と異なっている箇所があったため修正しました。

### 主な変更内容
- `doc/` -> `docs/`
- `doc/implementation/` -> `docs/implements/{{task_id}}/`

### 参考箇所
`tdd-red`, `tdd-green` などのコマンドを参考にしています。