### PR TITLE
feat: improve ipa-security-check and ipa-security-guide, bump to v1.4.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tsumiki",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "AI-driven development toolkit for TDD and SDD workflows, providing comprehensive command templates and agents to enhance developer productivity with Claude Code",
   "author": {
     "name": "makoto kuroeda",

--- a/skills/ipa-security-check/SKILL.md
+++ b/skills/ipa-security-check/SKILL.md
@@ -47,7 +47,7 @@ IPA (情報処理推進機構) が公開する以下 5 資料の指摘事項に�
    - verdict を `snippet_hash` で findings にマージ
    - 既存 Markdown レポートから triage ブロックを抽出 (`lib/triage_state.md` 準拠) し、`snippet_hash` 一致で新 findings にステータス引き継ぎ
    - `templates/report.md.tmpl` を埋めて Markdown を出力、SARIF 2.1.0 も同時生成
-7. デフォルトの保存先は `./ipa-security-report.md` と `./ipa-security-report.sarif` (`--output` で上書き)
+7. デフォルトの保存先は `./ipa-security-report-YYYY-MM-DD-NN.md` と `./ipa-security-report-YYYY-MM-DD-NN.sarif` (`--output` で上書き可)。同日に複数回実行した場合は連番 (`-01`, `-02`, ...) が自動付与され、既存レポートを上書きしない
 
 中間ファイルの作業ディレクトリは `.tmp/ipa-security-check/` (リポジトリルート直下、名前に `tmp` を含めること)。
 

--- a/skills/ipa-security-check/SKILL.md
+++ b/skills/ipa-security-check/SKILL.md
@@ -47,7 +47,7 @@ IPA (情報処理推進機構) が公開する以下 5 資料の指摘事項に�
    - verdict を `snippet_hash` で findings にマージ
    - 既存 Markdown レポートから triage ブロックを抽出 (`lib/triage_state.md` 準拠) し、`snippet_hash` 一致で新 findings にステータス引き継ぎ
    - `templates/report.md.tmpl` を埋めて Markdown を出力、SARIF 2.1.0 も同時生成
-7. デフォルトの保存先は `./ipa-security-report-YYYY-MM-DD-NN.md` と `./ipa-security-report-YYYY-MM-DD-NN.sarif` (`--output` で上書き可)。同日に複数回実行した場合は連番 (`-01`, `-02`, ...) が自動付与され、既存レポートを上書きしない
+7. デフォルトの保存先は `./security-reports/ipa-security-report-YYYY-MM-DD-NN.md` と `./security-reports/ipa-security-report-YYYY-MM-DD-NN.sarif` (`--output` で上書き可)。`security-reports/` ディレクトリが存在しない場合は自動作成する。同日に複数回実行した場合は連番 (`-01`, `-02`, ...) が自動付与され、既存レポートを上書きしない
 
 中間ファイルの作業ディレクトリは `.tmp/ipa-security-check/` (リポジトリルート直下、名前に `tmp` を含めること)。
 

--- a/skills/ipa-security-check/commands/ipa-security-check.md
+++ b/skills/ipa-security-check/commands/ipa-security-check.md
@@ -21,7 +21,7 @@ IPA「安全なウェブサイトの作り方 改訂第7版」ほか 4 資料に
 | `--diff` | 任意 | 現ブランチと `main` の差分ファイルのみを対象 |
 | `--categories <list>` | 任意 | カンマ区切りでカテゴリ限定。指定可能値: `sqli, oscmd, traversal, session, xss, csrf, http-header, mail-header, clickjacking, bof, access-control, safe-sql, whc, ops` |
 | `--severity <level>` | 任意 | 報告下限。`critical, high, medium, low, info` のいずれか。デフォルト `low` |
-| `--output <files>` | 任意 | カンマ区切りで出力ファイル指定。デフォルト `ipa-security-report-YYYY-MM-DD-NN.md,ipa-security-report-YYYY-MM-DD-NN.sarif`（日付・連番自動付与） |
+| `--output <files>` | 任意 | カンマ区切りで出力ファイル指定。デフォルト `security-reports/ipa-security-report-YYYY-MM-DD-NN.md,security-reports/ipa-security-report-YYYY-MM-DD-NN.sarif`（日付・連番自動付与、ディレクトリ自動作成） |
 
 ## 使用例
 

--- a/skills/ipa-security-check/commands/ipa-security-check.md
+++ b/skills/ipa-security-check/commands/ipa-security-check.md
@@ -21,7 +21,7 @@ IPA「安全なウェブサイトの作り方 改訂第7版」ほか 4 資料に
 | `--diff` | 任意 | 現ブランチと `main` の差分ファイルのみを対象 |
 | `--categories <list>` | 任意 | カンマ区切りでカテゴリ限定。指定可能値: `sqli, oscmd, traversal, session, xss, csrf, http-header, mail-header, clickjacking, bof, access-control, safe-sql, whc, ops` |
 | `--severity <level>` | 任意 | 報告下限。`critical, high, medium, low, info` のいずれか。デフォルト `low` |
-| `--output <files>` | 任意 | カンマ区切りで出力ファイル指定。デフォルト `ipa-security-report.md,ipa-security-report.sarif` |
+| `--output <files>` | 任意 | カンマ区切りで出力ファイル指定。デフォルト `ipa-security-report-YYYY-MM-DD-NN.md,ipa-security-report-YYYY-MM-DD-NN.sarif`（日付・連番自動付与） |
 
 ## 使用例
 

--- a/skills/ipa-security-check/lib/orchestrator.md
+++ b/skills/ipa-security-check/lib/orchestrator.md
@@ -307,22 +307,33 @@ prompt: <下記>
 
 `lib/output_formatter.md` と `templates/report.md.tmpl` の仕様は `scripts/render_report.py` に実装済み。メインは以下を Bash で実行する:
 
+**`--output` が省略されている場合**: 以下の Bash で日付・連番付きのファイル名を決定してから `render_report.py` を実行する:
+
 ```bash
+DATE=$(date +%Y-%m-%d)
+NN=01
+while [ -f "./ipa-security-report-${DATE}-${NN}.md" ]; do
+  NN=$(printf "%02d" $((10#$NN + 1)))
+done
+MD_OUT="./ipa-security-report-${DATE}-${NN}.md"
+SARIF_OUT="./ipa-security-report-${DATE}-${NN}.sarif"
+
 python3 .claude/skills/ipa-security-check/scripts/render_report.py \
     .tmp/ipa-security-check/findings_with_hash.json \
     .tmp/ipa-security-check/verdicts.json \
-    ./ipa-security-report.md \
-    ./ipa-security-report.sarif \
+    "$MD_OUT" \
+    "$SARIF_OUT" \
     --scope-summary "<scope の人間可読要約>" \
     --files-scanned <N>
 ```
+
+**`--output` が指定されている場合**: 指定された値を第 3・第 4 引数として使う。
 
 このスクリプトが行う処理:
 1. verdict を `snippet_hash` で findings にマージ (Step 5.4 相当)
 2. 出力先 Markdown が存在すれば triage を引き継ぎ (Step 6 相当)
 3. 3 セクション振り分け / サマリ集計 / `templates/report.md.tmpl` 置換 / SARIF 生成
 
-`--output` で別パスが指定されていれば、第 3・第 4 引数をそのパスに差し替える。
 最後にユーザーへ要約を 1〜2 文で報告する (件数とファイル名)。
 
 ---

--- a/skills/ipa-security-check/lib/orchestrator.md
+++ b/skills/ipa-security-check/lib/orchestrator.md
@@ -311,12 +311,13 @@ prompt: <下記>
 
 ```bash
 DATE=$(date +%Y-%m-%d)
+mkdir -p ./security-reports
 NN=01
-while [ -f "./ipa-security-report-${DATE}-${NN}.md" ]; do
+while [ -f "./security-reports/ipa-security-report-${DATE}-${NN}.md" ]; do
   NN=$(printf "%02d" $((10#$NN + 1)))
 done
-MD_OUT="./ipa-security-report-${DATE}-${NN}.md"
-SARIF_OUT="./ipa-security-report-${DATE}-${NN}.sarif"
+MD_OUT="./security-reports/ipa-security-report-${DATE}-${NN}.md"
+SARIF_OUT="./security-reports/ipa-security-report-${DATE}-${NN}.sarif"
 
 python3 .claude/skills/ipa-security-check/scripts/render_report.py \
     .tmp/ipa-security-check/findings_with_hash.json \

--- a/skills/ipa-security-guide/SKILL.md
+++ b/skills/ipa-security-guide/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ipa-security-guide
 description: ipa-security-check をはじめとするセキュリティ診断ツールが出力したレポートを読み込み、各検出項目を優先順位付きの dev-debug 依頼リストに変換する。対象プロジェクトの言語・FWを問わず汎用的に使える。コードベースを直接読んでアーキテクチャ判断を行う。
-argument-hint: "[レポートファイルパス (省略時: ./ipa-security-report.md)] [-o 出力ファイルパス]"
+argument-hint: "[レポートファイルパス (省略時: ipa-security-report-*.md を自動検出)] [-o 出力ファイルパス]"
 ---
 
 # IPA Security Guide Skill
@@ -25,7 +25,10 @@ argument-hint: "[レポートファイルパス (省略時: ./ipa-security-repor
 /ipa-security-guide <レポートファイルパス> -o <出力ファイルパス>
 ```
 
-- レポートファイルパスを省略した場合はカレントディレクトリの `ipa-security-report.md` を使う
+- レポートファイルパスを省略した場合は、カレントディレクトリで `ipa-security-report-*.md` に一致するファイルを自動検出する
+  - **1件のみ**: 自動で使用する
+  - **複数件**: ファイル名一覧を提示し、AskUserQuestion でユーザーに選んでもらう
+  - **0件**: `ipa-security-report.md` へのフォールバックを試みる。それも存在しない場合はエラーを報告して終了する
 - `-o` を指定した場合は結果をそのパスに Write する。省略した場合は画面出力のみ
 
 ## 前提条件
@@ -51,7 +54,7 @@ ipa-security-guide/
 
 以下をすべて Read する。件ごとに読み直さない。
 
-1. 指定された（または `./ipa-security-report.md`）レポートファイル
+1. レポートファイル（「起動方法」のファイル検出ルールに従って特定する）
    - 存在しない場合はエラーを報告して終了
    - レポートのヘッダーからプロジェクトのルートディレクトリを推定する
 2. `knowledge/triage.md`

--- a/skills/ipa-security-guide/SKILL.md
+++ b/skills/ipa-security-guide/SKILL.md
@@ -25,7 +25,7 @@ argument-hint: "[レポートファイルパス (省略時: ipa-security-report-
 /ipa-security-guide <レポートファイルパス> -o <出力ファイルパス>
 ```
 
-- レポートファイルパスを省略した場合は、カレントディレクトリで `ipa-security-report-*.md` に一致するファイルを自動検出する
+- レポートファイルパスを省略した場合は、`security-reports/ipa-security-report-*.md` を優先して自動検出する。見つからない場合はカレントディレクトリの `ipa-security-report-*.md` も検索する
   - **1件のみ**: 自動で使用する
   - **複数件**: ファイル名一覧を提示し、AskUserQuestion でユーザーに選んでもらう
   - **0件**: `ipa-security-report.md` へのフォールバックを試みる。それも存在しない場合はエラーを報告して終了する


### PR DESCRIPTION
## Summary

- **ipa-security-check**: レポートの出力ファイル名をデフォルトで日付・連番付き形式（`ipa-security-report-YYYY-MM-DD-NN.md`）に変更。繰り返しスキャン時に既存レポートを上書きしない
- **ipa-security-guide**: レポートファイルパスを省略した場合に `ipa-security-report-*.md` を自動検出するよう変更。複数件ある場合はユーザーに選択を促す
- バージョンを 1.4.1 → **1.4.2** にバンプ

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `skills/ipa-security-check/SKILL.md` | デフォルト出力ファイル名の説明を更新 |
| `skills/ipa-security-check/commands/ipa-security-check.md` | `--output` デフォルト値の説明を更新 |
| `skills/ipa-security-check/lib/orchestrator.md` | Step 7 に日付・連番ファイル名の動的生成ロジックを追加 |
| `skills/ipa-security-guide/SKILL.md` | レポートファイルの自動検出・選択ロジックを追加 |
| `.claude-plugin/plugin.json` | バージョン 1.4.1 → 1.4.2 |

## 背景

`ipa-security-check` を同一プロジェクトで複数回実行した場合、デフォルトでは `ipa-security-report.md` に上書きされてしまい、過去のスキャン結果を参照できなかった。日付・連番形式にすることで、複数の実行結果を保持できる。

また `ipa-security-guide` は連番形式のレポートに対応するため、ファイルパス省略時に `ipa-security-report-*.md` を自動検出するよう変更した。

## Test plan

- [ ] `ipa-security-check` を2回実行し、`ipa-security-report-YYYY-MM-DD-01.md` と `-02.md` が生成されることを確認
- [ ] `ipa-security-guide` を引数なしで起動し、レポートファイルが自動検出されることを確認
- [ ] 複数のレポートファイルがある場合に選択プロンプトが表示されることを確認
- [ ] `--output` 指定時は従来通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)